### PR TITLE
Fixed instructions for phone number

### DIFF
--- a/_lab/lab03.md
+++ b/_lab/lab03.md
@@ -150,7 +150,7 @@ def isPhoneNumber(digits):
     '''
     - Nithya asked for Nassim's phone number. She wants to write a function 
       to check if the number is a real phone number.
-    - Returns True if `digits` is of type int and is nine numbers long.
+    - Returns True if `digits` is of type int and is ten numbers long.
     - Hint 1: You can check if digits is an int with type(digits) == int
     - Hint 2: To check the length of digits, you must convert it to a string first 
       using str(digits).


### PR DESCRIPTION
It originally said that the phone number should return true if it is 9 digits long, however it should be10